### PR TITLE
Python3 support for import xmodel, reload button, and xanim notetrack

### DIFF
--- a/CoDMayaTools.py
+++ b/CoDMayaTools.py
@@ -53,6 +53,7 @@ import shutil
 import zipfile
 import re
 import json
+from importlib import reload
 from PyCoD import xmodel as xModel
 from PyCoD import xanim as xAnim
 from array import array
@@ -204,7 +205,7 @@ def CreateMenu():
     cmds.setParent(menu, menu=True)
     cmds.menuItem(divider=True)
     # For easy script updating
-    cmds.menuItem(label="Reload Script", command="reload(CoDMayaTools)")
+    cmds.menuItem(label="Reload Script", command=lambda x:reload(sys.modules[__name__]))
 
     # Tools Info
     cmds.menuItem(label="About", command=lambda x:AboutWindow())
@@ -289,7 +290,7 @@ def ReadNullTerminatedString(f):
     byte = f.read(1)
     string = ""
     while struct.unpack('B', byte)[0] != 0:
-        string += byte
+        string += byte.decode()
         byte = f.read(1)
 
     return string
@@ -751,7 +752,7 @@ def LoadMaterials(lod, codRootPath):
 
                 # Extract from zip
                 source = zip.open("images/%s%s" % (mapName, ".iwi"))
-                target = file(outPath, "wb")
+                target = open(outPath, "wb")
                 shutil.copyfileobj(source, target)
                 source.close()
                 target.close()
@@ -970,7 +971,7 @@ def GetJointList(export_type=None):
                 # Check for automatic rename.
                 if QueryToggableOption("AutomaticRename"):
                     # Run over dictonary for possible joints to rename.
-                    for potjoints, new_name in RENAME_DICTONARY.iteritems():
+                    for potjoints, new_name in RENAME_DICTONARY.items():
                         # Found one
                         if bone_name == potjoints[0]:
                             # Check if it's a child bone of what we want, None to rename regardless.
@@ -2605,7 +2606,7 @@ def ReadNotetracks(windowID):
     notetracks = __get_notetracks__()
     # Add notetrack type prefix automatically
     write_note_type = QueryToggableOption('PrefixNoteType')
-    for note, frames in notetracks.iteritems():
+    for note, frames in notetracks.items():
         # Ignore end/loop_end
         if note == "end" or note == "loop_end":
             continue


### PR DESCRIPTION
Importing xmodels failed due to the way strings have changed in python3. Simply decoding the byte to utf-8 (default) should fix this.

reload function is no longer builtin in python3, so use importlib.reload instead.

iteritems is no longer an attribute of dict in python3, so use items instead.

file should be replaced with open.